### PR TITLE
fix: ensure Tailwind CSS import

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,4 @@
+@import "tailwindcss";
 @custom-variant dark (&:is(.dark *));
 
 :root {


### PR DESCRIPTION
## Summary
- import Tailwind in global stylesheet so utility classes get generated

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@radix-ui/react-accordion@1.2.3')*


------
https://chatgpt.com/codex/tasks/task_e_689d3f24e5b8832d8a41059de505bd1d