### PR TITLE
feat: add navigation header for manager and employee pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import Header from "@/components/header";
 
 export const metadata: Metadata = {
   title: "Imagination",
@@ -13,7 +14,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className="bg-gray-50">
+        <Header />
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
-import ManagerDashboard from '@/components/manager-dashboard';
+import { redirect } from 'next/navigation';
 
 export default function Home() {
-  return <ManagerDashboard />;
+  redirect('/manager');
 }
+

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export default function Header() {
+  const pathname = usePathname();
+
+  const navItems = [
+    { href: '/manager', label: 'Manager' },
+    { href: '/employee', label: 'Employee' }
+  ];
+
+  return (
+    <header className="border-b bg-white">
+      <nav className="max-w-4xl mx-auto flex h-12 items-center gap-6 px-6">
+        {navItems.map(item => {
+          const isActive = pathname.startsWith(item.href);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`text-sm transition-colors hover:text-gray-900 ${
+                isActive ? 'text-gray-900 font-medium' : 'text-gray-500'
+              }`}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add shared header with manager and employee links
- include header in layout and redirect root to manager page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d51dcb574832d8b3af86eae2b8701